### PR TITLE
fix batch update

### DIFF
--- a/lib/data/book.js
+++ b/lib/data/book.js
@@ -22,7 +22,9 @@ module.exports = (h = {}, args = {}) => ({ state = {}, data = {} } = {}) => {
     : new OrderBook(original, raw)
 
   if (books[key]) {
-    nextBook.updateWith(original)
+    const entries = Array.isArray(original[0]) ? original : [original]
+
+    entries.forEach(entry => nextBook.updateWith(entry))
   }
 
   ev.emit('data:managed:book', {

--- a/lib/data/book.js
+++ b/lib/data/book.js
@@ -22,7 +22,7 @@ module.exports = (h = {}, args = {}) => ({ state = {}, data = {} } = {}) => {
     : new OrderBook(original, raw)
 
   if (books[key]) {
-    const entries = Array.isArray(original[0]) ? original : [original]
+    const entries = !original.length || Array.isArray(original[0]) ? original : [original]
 
     entries.forEach(entry => nextBook.updateWith(entry))
   }


### PR DESCRIPTION
### Description

In the case when the API sends an array of Order books, we face the following problem:

![image](https://user-images.githubusercontent.com/70510980/122592405-e57aae80-d06c-11eb-8999-bbe947ef78e7.png)

Therefore, this data will be perceived as an Order book, which is not correct


### Fixes:
- [x] Fix update of existing Order book when argument is an array of Order book (property `original` can contain an array of order books that emitted by [data:book](https://github.com/bitfinexcom/bfx-api-node-core/blob/master/lib/ws2/messages/books.js#L50)
